### PR TITLE
Intercept also BTN_MOUSE events

### DIFF
--- a/service
+++ b/service
@@ -26,7 +26,7 @@ state = dict(
 
 def device_event(event):
     # print >>sys.stderr, event.type, event.code
-    if event.type == ecodes.EV_KEY and event.code == ecodes.BTN_TOUCH:
+    if event.type == ecodes.EV_KEY and (event.code == ecodes.BTN_TOUCH or event.code == ecodes.BTN_MOUSE):
         state['down'] = event.value != 0
     if event.type == ecodes.EV_ABS:
         if event.code == ecodes.ABS_X:

--- a/service
+++ b/service
@@ -26,7 +26,7 @@ state = dict(
 
 def device_event(event):
     # print >>sys.stderr, event.type, event.code
-    if event.type == ecodes.EV_KEY and (event.code == ecodes.BTN_TOUCH or event.code == ecodes.BTN_MOUSE):
+    if event.type == ecodes.EV_KEY and event.code in (ecodes.BTN_TOUCH, ecodes.BTN_MOUSE):
         state['down'] = event.value != 0
     if event.type == ecodes.EV_ABS:
         if event.code == ecodes.ABS_X:


### PR DESCRIPTION
Make the package able to intercept also BTC_MOUSE events. This is useful in case of different touch monitors that are recognized as mouse by the raspberry pi